### PR TITLE
Update webpack configuration for storybook to avoid a "describe" import error.

### DIFF
--- a/.storybook/fakeTestSuite.js
+++ b/.storybook/fakeTestSuite.js
@@ -1,0 +1,3 @@
+export function describe() {
+
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const webpack = require('webpack');
+const path = require('path');
+const defaultConfigGenerator = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
+
+module.exports = (baseConfig, env) => {
+    const config = defaultConfigGenerator(baseConfig, env);
+
+    addFakeTestSuitePlugin(config);
+
+    return config;
+};
+
+function addFakeTestSuitePlugin(config) {
+    // This "faking" of describe allows us to directly import some code from
+    // test files into storybook.
+    // The idea is to create a default component that will be firs tested,
+    // then imported in storybook to be displayed.
+    const fakeTestSuitePath = path.join(__dirname, 'fakeTestSuite.js');
+    const testSuiteProvider = new webpack.ProvidePlugin({
+        'describe': [fakeTestSuitePath, 'describe']
+    });
+    config.plugins.push(testSuiteProvider);
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "devDependencies": {
     "@storybook/react": "^3.3.11",
-    "babel-core": "^6.26.0"
+    "babel-core": "^6.26.0",
+    "chai": "^4.1.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,json,css}": [

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,8 @@
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+
 const localStorageMock = {
   getItem: jest.fn(),
   setItem: jest.fn(),


### PR DESCRIPTION
We currently import some test files from storybook ones to be sure that all stories are on tested components.
As Webpack doesn't know `describe`, we fake it to avoid this import error.