### PR TITLE
Update Overlay component to use react-modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prettier": "^1.10.2",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-modal": "^3.3.2",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.0",

--- a/src/components/login/HeaderLogin.jsx
+++ b/src/components/login/HeaderLogin.jsx
@@ -24,13 +24,11 @@ class HeaderLogin extends React.Component {
     const { onLoginSuccess } = this.props;
     const displayOverlay = this.state.overlayDisplay;
 
-    if (displayOverlay) {
-      return (
-        <Overlay onClose={this.onClose}>
-          <LoginForm onLoginSuccess={onLoginSuccess} />
-        </Overlay>
-      );
-    }
+    return (
+      <Overlay onClose={this.onClose} displayOverlay={displayOverlay}>
+        <LoginForm onLoginSuccess={onLoginSuccess} />
+      </Overlay>
+    );
   };
 
   render() {

--- a/src/components/login/HeaderLogin.spec.js
+++ b/src/components/login/HeaderLogin.spec.js
@@ -20,7 +20,7 @@ describe('<HeaderLogin/>', () => {
 
   it('does not display overlay by default', () => {
     const wrapper = mount(givenDefaultHeaderLogin());
-    expect(findOverlay(wrapper)).to.have.length(0);
+    expect(findOverlay(wrapper).prop('displayOverlay')).to.equal(false);
   });
 
   it('displays overlay after click', () => {

--- a/src/components/overlay/Overlay.jsx
+++ b/src/components/overlay/Overlay.jsx
@@ -1,17 +1,20 @@
 import React from 'react';
+import Modal from 'react-modal';
 
 import CloseSign from './CloseSign';
 import './Overlay.css';
 
+Modal.setAppElement('body');
+
 class Overlay extends React.Component {
   render() {
-    const { onClose } = this.props;
+    const { onClose, displayOverlay } = this.props;
 
     return (
-      <div className="overlay">
+      <Modal isOpen={displayOverlay} onRequestClose={onClose}>
         <CloseSign onClose={onClose} />
         {this.props.children}
-      </div>
+      </Modal>
     );
   }
 }

--- a/src/components/overlay/Overlay.spec.js
+++ b/src/components/overlay/Overlay.spec.js
@@ -12,11 +12,10 @@ describe('<Overlay/>', () => {
 
   it('renders passed children without alteration', () => {
     const wrapper = mount(
-      <Overlay>
+      <Overlay displayOverlay={true}>
         <span className="span-child-testingonly">This is an overlay child</span>
       </Overlay>
     );
-    expect(wrapper.find('.span-child-testingonly')).to.have.length(1);
     expect(wrapper.find('.span-child-testingonly').text()).to.equal(
       'This is an overlay child'
     );
@@ -24,7 +23,9 @@ describe('<Overlay/>', () => {
 
   it('triggers "onClose" action when clicking on close sign', () => {
     const onCloseSpy = sinon.spy();
-    const wrapper = mount(<Overlay onClose={onCloseSpy} />);
+    const wrapper = mount(
+      <Overlay onClose={onCloseSpy} displayOverlay={true} />
+    );
     findCloseSign(wrapper).simulate('click');
     expect(onCloseSpy.called).to.be.true;
   });
@@ -37,7 +38,7 @@ describe('<Overlay/>', () => {
 export function givenDefaultOverlay() {
   const onClose = () => alert('Closing overlay action');
   return (
-    <Overlay onClose={onClose}>
+    <Overlay onClose={onClose} displayOverlay={true}>
       <span>This is an overlay content</span>
     </Overlay>
   );


### PR DESCRIPTION
`react-modal` applies the proper React Portal pattern to handle modals by attaching them to a different node than the one where the component is used.