### PR TITLE
Add logout server API call

### DIFF
--- a/src/api/cookies.js
+++ b/src/api/cookies.js
@@ -1,0 +1,7 @@
+export function getCSRFTokenCookieValue() {
+  var cookieValue = document.cookie.replace(
+    /(?:(?:^|.*;\s*)csrftoken\s*=\s*([^;]*).*$)|^.*$/,
+    '$1'
+  );
+  return cookieValue;
+}

--- a/src/api/logUser.js
+++ b/src/api/logUser.js
@@ -1,6 +1,10 @@
 import 'whatwg-fetch';
 
-import { getGraphQLEndpointURL } from '../config/server';
+import {
+  getGraphQLEndpointURL,
+  getGraphQLPrivateEndpointURL
+} from '../config/server';
+import { getCSRFTokenCookieValue } from './cookies';
 
 function buildLogInUserPayload(email, password) {
   return {
@@ -14,6 +18,35 @@ function buildLogInUserPayload(email, password) {
     }`,
     variables: { email, password }
   };
+}
+
+function buildLogOutUserPayload() {
+  return {
+    query: `mutation {
+      logoutUser {
+        user {
+          email
+        }
+      }
+    }`
+  };
+}
+
+export function apiLogOutUser(data) {
+  const GRAPHQL_ENDPOINT = getGraphQLPrivateEndpointURL();
+  const payload = buildLogOutUserPayload();
+
+  return fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFTokenCookieValue()
+    },
+    // Used to tell the server to send the Set-Cookie response header
+    // containing user credentials (sessionid in case of Django basic auth)
+    credentials: 'include',
+    body: JSON.stringify(payload)
+  });
 }
 
 export function apiLogInUser(data) {

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -14,3 +14,8 @@ export function getGraphQLEndpointURL() {
   const serverRootURL = getServerRootURL();
   return urljoin(serverRootURL, 'graphql/');
 }
+
+export function getGraphQLPrivateEndpointURL() {
+  const serverRootURL = getServerRootURL();
+  return urljoin(serverRootURL, 'private_graphql/');
+}


### PR DESCRIPTION
- Add new URL endpoint (actions that require authentication are on a different endpoint than the public ones),
- Pass CSRF value in the HTTP header (private server API call endpoint is currently cookie-based and CSRF protected)