### PR TITLE
Introduce whoami query, solely used at the initialisation of the page to check if the customer is logged.

### DIFF
--- a/src/api/whoami.js
+++ b/src/api/whoami.js
@@ -1,0 +1,27 @@
+import 'whatwg-fetch';
+
+import { getGraphQLPrivateEndpointURL } from '../config/server';
+import { getCSRFTokenCookieValue } from './cookies';
+
+function buildWhoAmIPayload() {
+  return {
+    query: `{ whoami }`
+  };
+}
+
+export function apiWhoAmI() {
+  const GRAPHQL_ENDPOINT = getGraphQLPrivateEndpointURL();
+  const payload = buildWhoAmIPayload();
+
+  return fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFTokenCookieValue()
+    },
+    // Used to tell the server to send the Set-Cookie response header
+    // containing user credentials (sessionid in case of Django basic auth)
+    credentials: 'include',
+    body: JSON.stringify(payload)
+  });
+}


### PR DESCRIPTION
It will return later a structured data layer, currently only a non-used string.
The main idea is to initially check the status code of the response (401 -> not logged, 200 -> logged)